### PR TITLE
add basic typescript typing for parse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+
+
+export function parse(source: string, transform?: Function): any[]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && tape test.js"
   },
@@ -29,6 +30,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "readme.md"
   ]
 }


### PR DESCRIPTION
Here is the basic typescript typing for the function parse. This allows (without having to write custom ambient declaration for postgres-array/parse): 

```ts
import { types } from 'pg';
import { parse } from 'postgres-array';

// 1016: _int8 (i.e., int8[])
types.setTypeParser(1016, function (val: string) {
  return pgArrayParse(val, parseInt); // will do BigInt once supported by TS (planned 3.1)
});
```