### PR TITLE
Faster array parsing

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -17,6 +17,19 @@ const WORDS = [
     '"'
 ]
 
+/**
+ * V8 strings are often created as "ropes"; however when we receive data from
+ * the database it won't be a rope but a flattened string. Thus to benchmark
+ * fairly, we must operate on flattened strings.
+ *
+ * @see {@link https://github.com/davidmarkclements/flatstr/blob/master/index.js}
+ */
+function flattenString (str) {
+  // eslint-disable-next-line no-unused-expressions
+  str | 0
+  return str
+}
+
 for (let i = 0; i < 1000; i++) {
   const parts = []
   for (let j = 100; j < 500; j++) {
@@ -26,7 +39,7 @@ for (let i = 0; i < 1000; i++) {
     }
     parts.push('{' + innerParts.join(',') + '}')
   }
-  arraysToParse.push('{' + parts.join(',') + '}')
+  arraysToParse.push(flattenString('{' + parts.join(',') + '}'))
 }
 for (let i = 0; i < 1000; i++) {
   const parts = []

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const array = require('./')
+const { parse } = array
+const arraysToParse = []
+// We have to manually escape these
+const WORDS = [
+  'HELLO',
+  'WORLD',
+  '"' + 'Mixed \\"content\\"'.repeat(100) + '"',
+  '1984',
+  String(Math.MAX_SAFE_INTEGER),
+  '""',
+  '"{}"',
+  '"' +
+    JSON.stringify({ test: { this: { out: true } } }).replace(/"/g, '\\"') +
+    '"'
+]
+
+for (let i = 0; i < 1000; i++) {
+  const parts = []
+  for (let j = 100; j < 500; j++) {
+    const innerParts = []
+    for (let k = 0; k < 2; k++) {
+      innerParts.push(WORDS[(i + j + k) % WORDS.length])
+    }
+    parts.push('{' + innerParts.join(',') + '}')
+  }
+  arraysToParse.push('{' + parts.join(',') + '}')
+}
+for (let i = 0; i < 1000; i++) {
+  const parts = []
+  for (let j = 100; j < 500; j++) {
+    const innerParts = []
+    for (let k = 0; k < 2; k++) {
+      innerParts.push(String(i + j + k))
+    }
+    parts.push('{' + innerParts.join(',') + '}')
+  }
+  arraysToParse.push('{' + parts.join(',') + '}')
+}
+
+const l = arraysToParse.length
+console.log(`To process: ${l} arrays`)
+
+async function main () {
+  for (let i = 0; i < 10; i++) {
+    // Store results so V8 doesn't optimize away our loop
+    let previousResult, currentResult
+    const start = process.hrtime()
+
+    for (let i = 0; i < l; i++) {
+      previousResult = currentResult
+      currentResult = parse(arraysToParse[i])
+    }
+    const fin = process.hrtime(start)
+    const dur = fin[0] * 1e3 + fin[1] * 1e-6
+
+    console.log(previousResult ? '' : 'f')
+
+    console.log(
+      `Parsing ${l} arrays took ${dur.toFixed(1)}ms (${(l / dur).toFixed(
+        1
+      )} arrays/ms)`
+    )
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/benchmark.js
+++ b/benchmark.js
@@ -9,7 +9,7 @@ const WORDS = [
   'WORLD',
   '"' + 'Mixed \\"content\\"'.repeat(100) + '"',
   '1984',
-  String(Math.MAX_SAFE_INTEGER),
+  String(Number.MAX_SAFE_INTEGER),
   '""',
   '"{}"',
   '"' +

--- a/index.js
+++ b/index.js
@@ -95,19 +95,10 @@ function makeParseArrayWithTransform (transform) {
         current = arr
       } else if (expectValue) {
         currentStringStart = position
-        const comma = str.indexOf(COMMA, currentStringStart)
-        const rbrace = str.indexOf(RBRACE, currentStringStart)
-        if (comma === -1) {
-          if (rbrace === -1) {
-            position = rbraceIndex
-          } else {
-            position = rbrace
-          }
-        } else {
-          if (rbrace === -1) {
-            position = comma
-          } else {
-            position = Math.min(comma, rbrace)
+        for (; position < rbraceIndex; ++position) {
+          const char = str[position]
+          if (char === COMMA || char === RBRACE) {
+            break
           }
         }
         const part = str.slice(currentStringStart, position--)

--- a/index.js
+++ b/index.js
@@ -52,103 +52,85 @@ function makeParseArrayWithTransform (transform) {
       // > they are empty strings, contain curly braces, delimiter characters, double
       // > quotes, backslashes, or white space, or match the word NULL. Double quotes
       // > and backslashes embedded in element values will be backslash-escaped.
-      switch (char) {
-        case DQUOT: {
-          // It's escaped
-          currentStringStart = ++position
-          let dquot = str.indexOf(DQUOT, currentStringStart)
-          let backSlash = str.indexOf(BACKSLASH, currentStringStart)
-          while (backSlash !== -1 && backSlash < dquot) {
-            position = backSlash
-            const part = str.slice(currentStringStart, position)
-            currentStringParts.push(part)
-            hasStringParts = true
-            currentStringStart = ++position
-            if (dquot === position++) {
-              // This was an escaped doublequote; find the next one!
-              dquot = str.indexOf(DQUOT, position)
-            }
-            // Either way, find the next backslash
-            backSlash = str.indexOf(BACKSLASH, position)
-          }
-          position = dquot
+      if (char === DQUOT) {
+        // It's escaped
+        currentStringStart = ++position
+        let dquot = str.indexOf(DQUOT, currentStringStart)
+        let backSlash = str.indexOf(BACKSLASH, currentStringStart)
+        while (backSlash !== -1 && backSlash < dquot) {
+          position = backSlash
           const part = str.slice(currentStringStart, position)
-          if (hasStringParts) {
-            const final = currentStringParts.join('') + part
-            current.push(haveTransform ? transform(final) : final)
-            currentStringParts.length = 0
-            hasStringParts = false
-          } else {
-            current.push(haveTransform ? transform(part) : part)
+          currentStringParts.push(part)
+          hasStringParts = true
+          currentStringStart = ++position
+          if (dquot === position++) {
+            // This was an escaped doublequote; find the next one!
+            dquot = str.indexOf(DQUOT, position)
           }
-          mode = EXPECT_DELIM
-          break
+          // Either way, find the next backslash
+          backSlash = str.indexOf(BACKSLASH, position)
         }
-        case LBRACE: {
-          const newArray = []
-          current.push(newArray)
-          stack.push(current)
-          current = newArray
-          currentStringStart = position + 1
-          mode = EXPECT_VALUE
-          break
+        position = dquot
+        const part = str.slice(currentStringStart, position)
+        if (hasStringParts) {
+          const final = currentStringParts.join('') + part
+          current.push(haveTransform ? transform(final) : final)
+          currentStringParts.length = 0
+          hasStringParts = false
+        } else {
+          current.push(haveTransform ? transform(part) : part)
         }
-        case COMMA: {
-          // delim();
-          if (mode === SIMPLE_VALUE) {
-            const part = str.slice(currentStringStart, position)
-            current.push(
-              part === NULL_STRING
-                ? null
-                : haveTransform
-                  ? transform(part)
-                  : part
-            )
-          }
+        mode = EXPECT_DELIM
+      } else if (char === LBRACE) {
+        const newArray = []
+        current.push(newArray)
+        stack.push(current)
+        current = newArray
+        currentStringStart = position + 1
+        mode = EXPECT_VALUE
+      } else if (char === COMMA) {
+        // delim();
+        if (mode === SIMPLE_VALUE) {
+          const part = str.slice(currentStringStart, position)
+          current.push(
+            part === NULL_STRING
+              ? null
+              : haveTransform
+                ? transform(part)
+                : part
+          )
+        }
 
-          mode = EXPECT_VALUE
-          break
+        mode = EXPECT_VALUE
+      } else if (char === RBRACE) {
+        // delim();
+        if (mode === SIMPLE_VALUE) {
+          const part = str.slice(currentStringStart, position)
+          current.push(
+            part === NULL_STRING
+              ? null
+              : haveTransform
+                ? transform(part)
+                : part
+          )
         }
-        case RBRACE: {
-          // delim();
-          if (mode === SIMPLE_VALUE) {
-            const part = str.slice(currentStringStart, position)
-            current.push(
-              part === NULL_STRING
-                ? null
-                : haveTransform
-                  ? transform(part)
-                  : part
-            )
-          }
 
-          mode = EXPECT_DELIM
-          const arr = stack.pop()
-          if (arr === undefined) {
-            throw new Error('Invalid array text - too many \'}\'')
-          }
-          current = arr
-          break
+        mode = EXPECT_DELIM
+        const arr = stack.pop()
+        if (arr === undefined) {
+          throw new Error("Invalid array text - too many '}'")
         }
-        default: {
-          switch (mode) {
-            case EXPECT_VALUE: {
-              currentStringStart = position
-              mode = SIMPLE_VALUE
-              break
-            }
-            case SIMPLE_VALUE: {
-              continue
-            }
-            case EXPECT_DELIM: {
-              throw new Error('Was expecting delimeter')
-            }
-            default: {
-              const never = mode
-              throw new Error(`Was not expecting to be in mode ${never}`)
-            }
-          }
-        }
+        current = arr
+      } else if (mode === EXPECT_VALUE) {
+        currentStringStart = position
+        mode = SIMPLE_VALUE
+      } else if (mode === SIMPLE_VALUE) {
+        continue
+      } else if (mode === EXPECT_DELIM) {
+        throw new Error('Was expecting delimeter')
+      } else {
+        const never = mode
+        throw new Error(`Was not expecting to be in mode ${never}`)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function makeParseArrayWithTransform (transform) {
     let expectValue = true
 
     for (; position < rbraceIndex; ++position) {
-      const char = str[position]
+      let char = str[position]
       // > The array output routine will put double quotes around element values if
       // > they are empty strings, contain curly braces, delimiter characters, double
       // > quotes, backslashes, or white space, or match the word NULL. Double quotes
@@ -95,11 +95,12 @@ function makeParseArrayWithTransform (transform) {
         current = arr
       } else if (expectValue) {
         currentStringStart = position
-        for (; position < rbraceIndex; ++position) {
-          const char = str[position]
-          if (char === COMMA || char === RBRACE) {
-            break
-          }
+        while (
+          (char = str[position]) !== COMMA &&
+          char !== RBRACE &&
+          position < rbraceIndex
+        ) {
+          ++position
         }
         const part = str.slice(currentStringStart, position--)
         current.push(
@@ -118,6 +119,6 @@ function makeParseArrayWithTransform (transform) {
 const parseArray = makeParseArrayWithTransform()
 
 exports.parse = (source, transform) =>
-  transform
+  transform != null
     ? makeParseArrayWithTransform(transform)(source)
     : parseArray(source)

--- a/index.js
+++ b/index.js
@@ -42,15 +42,6 @@ exports.parse = function (source, transform) {
   let mode = EXPECT_VALUE
   const haveTransform = transform != null
 
-  function delim () {
-    if (mode === SIMPLE_VALUE) {
-      const part = source.slice(currentStringStart, position)
-      current.push(
-        part === NULL_STRING ? null : haveTransform ? transform(part) : part
-      )
-    }
-  }
-
   for (; position < rbraceIndex; position++) {
     const char = source[position]
     if (mode === QUOTED_VALUE) {
@@ -84,10 +75,24 @@ exports.parse = function (source, transform) {
       currentStringStart = position + 1
       mode = EXPECT_VALUE
     } else if (char === COMMA) {
-      delim()
+      // delim()
+      if (mode === SIMPLE_VALUE) {
+        const part = source.slice(currentStringStart, position)
+        current.push(
+          part === NULL_STRING ? null : haveTransform ? transform(part) : part
+        )
+      }
+
       mode = EXPECT_VALUE
     } else if (char === RBRACE) {
-      delim()
+      // delim()
+      if (mode === SIMPLE_VALUE) {
+        const part = source.slice(currentStringStart, position)
+        current.push(
+          part === NULL_STRING ? null : haveTransform ? transform(part) : part
+        )
+      }
+
       mode = EXPECT_DELIM
       const arr = stack.pop()
       if (arr === undefined) {
@@ -107,7 +112,13 @@ exports.parse = function (source, transform) {
     }
   }
 
-  delim()
+  // delim()
+  if (mode === SIMPLE_VALUE) {
+    const part = source.slice(currentStringStart, position)
+    current.push(
+      part === NULL_STRING ? null : haveTransform ? transform(part) : part
+    )
+  }
 
   if (stack.length !== 0) {
     throw new Error('array dimension not balanced')

--- a/index.js
+++ b/index.js
@@ -21,20 +21,20 @@ exports.parse = function (source, transform) {
   let position = 0
   if (source[position] === LBRACKET) {
     position = source.indexOf(EQUALS) + 1
-    if (position === 0) {
-      throw new Error('Invalid array text, array indexes not understood')
-    }
+    if (position === 0) throw new Error('invalid array text - bad indicies')
   }
 
   if (source[position++] !== LBRACE) {
-    throw new Error('Invalid array text - must start with {')
+    throw new Error('invalid array text - missing lbrace')
   }
+
   const rbraceIndex = source.length - 1
   if (source[rbraceIndex] !== RBRACE) {
-    throw new Error('Invalid array text - must end with }')
+    throw new Error('invalid array text - missing rbrace')
   }
-  const output = []
-  let current = output
+
+  const entries = []
+  let current = entries
   const stack = []
 
   let currentStringStart = position
@@ -91,8 +91,9 @@ exports.parse = function (source, transform) {
       mode = EXPECT_DELIM
       const arr = stack.pop()
       if (arr === undefined) {
-        throw new Error('Invalid array text - too many \'}\'')
+        throw new Error('array dimension not balanced')
       }
+
       current = arr
     } else if (mode === EXPECT_VALUE) {
       currentStringStart = position
@@ -100,18 +101,17 @@ exports.parse = function (source, transform) {
     } else if (mode === SIMPLE_VALUE) {
       continue
     } else if (mode === EXPECT_DELIM) {
-      throw new Error('Was expecting delimeter')
+      throw new Error('expected delimeter')
     } else {
-      const never = mode
-      throw new Error(`Was not expecting to be in mode ${never}`)
+      throw new Error('unexpected mode')
     }
   }
 
   delim()
 
   if (stack.length !== 0) {
-    throw new Error('Invalid array text - mismatched braces')
+    throw new Error('array dimension not balanced')
   }
 
-  return output
+  return entries
 }

--- a/test.js
+++ b/test.js
@@ -9,7 +9,21 @@ test(function (t) {
   t.deepEqual(string('{""}'), [''], 'empty string')
   t.deepEqual(string('{1,2,3}'), ['1', '2', '3'], 'numerics')
   t.deepEqual(string('{a,b,c}'), ['a', 'b', 'c'], 'strings')
-  t.deepEqual(string('{"\\"\\"\\"","\\\\\\\\\\\\"}'), ['"""', '\\\\\\'], 'escaped')
+  t.deepEqual(
+    string('{"\\"\\"\\"","\\\\\\\\\\\\"}'),
+    ['"""', '\\\\\\'],
+    'escaped'
+  )
+  t.deepEqual(
+    string(
+      '{{3021,663,"PATIENT SISTER",2013},{9876,336,"IMPATIENT SISTER",2014}}'
+    ),
+    [
+      ['3021', '663', 'PATIENT SISTER', '2013'],
+      ['9876', '336', 'IMPATIENT SISTER', '2014']
+    ],
+    'mixed'
+  )
   t.deepEqual(string('{NULL,NULL}'), [null, null], 'null')
 
   t.deepEqual(intArray('{1,2,3}'), [1, 2, 3], 'numerics')


### PR DESCRIPTION
Hello again; you may remember the [PR I raised against postgres-interval](https://github.com/bendrucker/postgres-interval/pull/34) to improve performance. Turns out my latest code uses nested arrays in Postgres very heavily, and it's hitting some major performance issues in `postgres-array`, so I've written a more efficient algorithm. This algorithm works by avoiding character-by-character string concatenation, instead pulling slices from the source string and using those in the output. It further avoids recursion and a few other performance issues.

Unlike last time, I do not include benchmarks. [The code that I plan to use in PostGraphile](https://github.com/graphile/crystal/blob/ab0dd0af39aa0bcf77cf68f3f55fb7edd5d6008a/grafast/dataplan-pg/src/parseArray.ts) is even further optimized than this, but the gains over this are minimal and the amount of extra code is significant so I thought you'd probably prefer this version :wink: 

I'm happy for you to just close this, I'm sharing it in the spirit of OSS since I've done the work and you might want it (or something like it). Thanks! :heart: 