### PR TITLE
Even faster array parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,14 @@ const NULL_STRING = 'NULL'
 function makeParseArrayWithTransform (transform) {
   const haveTransform = transform != null
   return function parseArray (str) {
+    const rbraceIndex = str.length - 1
+    if (rbraceIndex === 1) {
+      return []
+    }
+    if (str[rbraceIndex] !== RBRACE) {
+      throw new Error('Invalid array text - must end with }')
+    }
+
     // If starts with `[`, it is specifying the index boundas. Skip past first `=`.
     let position = 0
     if (str[position] === LBRACKET) {
@@ -29,17 +37,12 @@ function makeParseArrayWithTransform (transform) {
     if (str[position++] !== LBRACE) {
       throw new Error('Invalid array text - must start with {')
     }
-    const rbraceIndex = str.length - 1
-    if (str[rbraceIndex] !== RBRACE) {
-      throw new Error('Invalid array text - must end with }')
-    }
     const output = []
     let current = output
     const stack = []
 
     let currentStringStart = position
-    const currentStringParts = []
-    let hasStringParts = false
+    let currentString = null
     let expectValue = true
 
     for (; position < rbraceIndex; ++position) {
@@ -56,8 +59,11 @@ function makeParseArrayWithTransform (transform) {
         while (backSlash !== -1 && backSlash < dquot) {
           position = backSlash
           const part = str.slice(currentStringStart, position)
-          currentStringParts.push(part)
-          hasStringParts = true
+          if (currentString === null) {
+            currentString = part
+          } else {
+            currentString += part
+          }
           currentStringStart = ++position
           if (dquot === position++) {
             // This was an escaped doublequote; find the next one!
@@ -68,13 +74,12 @@ function makeParseArrayWithTransform (transform) {
         }
         position = dquot
         const part = str.slice(currentStringStart, position)
-        if (hasStringParts) {
-          const final = currentStringParts.join('') + part
-          current.push(haveTransform ? transform(final) : final)
-          currentStringParts.length = 0
-          hasStringParts = false
-        } else {
+        if (currentString === null) {
           current.push(haveTransform ? transform(part) : part)
+        } else {
+          currentString += part
+          current.push(haveTransform ? transform(currentString) : currentString)
+          currentString = null
         }
         expectValue = false
       } else if (char === LBRACE) {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function makeParseArrayWithTransform (transform) {
     const stack = []
 
     let currentStringStart = position
-    let currentString = null
+    let currentString = ''
     let expectValue = true
 
     for (; position < rbraceIndex; ++position) {
@@ -59,11 +59,7 @@ function makeParseArrayWithTransform (transform) {
         while (backSlash !== -1 && backSlash < dquot) {
           position = backSlash
           const part = str.slice(currentStringStart, position)
-          if (currentString === null) {
-            currentString = part
-          } else {
-            currentString += part
-          }
+          currentString += part
           currentStringStart = ++position
           if (dquot === position++) {
             // This was an escaped doublequote; find the next one!
@@ -74,13 +70,9 @@ function makeParseArrayWithTransform (transform) {
         }
         position = dquot
         const part = str.slice(currentStringStart, position)
-        if (currentString === null) {
-          current.push(haveTransform ? transform(part) : part)
-        } else {
-          currentString += part
-          current.push(haveTransform ? transform(currentString) : currentString)
-          currentString = null
-        }
+        currentString += part
+        current.push(haveTransform ? transform(currentString) : currentString)
+        currentString = ''
         expectValue = false
       } else if (char === LBRACE) {
         const newArray = []


### PR DESCRIPTION
Follow up to #19.

Sorry... once I have a benchmark script... :grimacing: This one is easier to review at least! String concatenation is faster than array accumulation and join in.

Also it turns out that the performance difference is more stark in Node 22; for some reason the older algorithm is _slower_ in Node 22 than Node 20 - this is probably why you were seeing the 5x!

3.0.1:

```
$ time node benchmark.js 
To process: 2000 arrays

Parsing 2000 arrays took 2332.4ms (0.9 arrays/ms)

Parsing 2000 arrays took 2322.7ms (0.9 arrays/ms)

Parsing 2000 arrays took 2269.5ms (0.9 arrays/ms)

Parsing 2000 arrays took 2353.7ms (0.8 arrays/ms)

Parsing 2000 arrays took 2318.9ms (0.9 arrays/ms)

Parsing 2000 arrays took 2285.3ms (0.9 arrays/ms)

Parsing 2000 arrays took 2324.4ms (0.9 arrays/ms)

Parsing 2000 arrays took 2270.2ms (0.9 arrays/ms)

Parsing 2000 arrays took 2301.3ms (0.9 arrays/ms)

Parsing 2000 arrays took 2315.4ms (0.9 arrays/ms)

real    0m23.261s
user    0m24.046s
sys     0m0.580s
```

3.0.2:

```
$ time node benchmark.js 
To process: 2000 arrays

Parsing 2000 arrays took 608.5ms (3.3 arrays/ms)

Parsing 2000 arrays took 543.8ms (3.7 arrays/ms)

Parsing 2000 arrays took 530.6ms (3.8 arrays/ms)

Parsing 2000 arrays took 532.6ms (3.8 arrays/ms)

Parsing 2000 arrays took 538.5ms (3.7 arrays/ms)

Parsing 2000 arrays took 525.5ms (3.8 arrays/ms)

Parsing 2000 arrays took 519.8ms (3.8 arrays/ms)

Parsing 2000 arrays took 530.5ms (3.8 arrays/ms)

Parsing 2000 arrays took 525.3ms (3.8 arrays/ms)

Parsing 2000 arrays took 522.2ms (3.8 arrays/ms)

real    0m5.524s
user    0m5.456s
sys     0m0.128s
```

This branch:

```
$ time node benchmark.js 
To process: 2000 arrays

Parsing 2000 arrays took 543.8ms (3.7 arrays/ms)

Parsing 2000 arrays took 432.8ms (4.6 arrays/ms)

Parsing 2000 arrays took 435.0ms (4.6 arrays/ms)

Parsing 2000 arrays took 428.6ms (4.7 arrays/ms)

Parsing 2000 arrays took 430.8ms (4.6 arrays/ms)

Parsing 2000 arrays took 429.0ms (4.7 arrays/ms)

Parsing 2000 arrays took 426.1ms (4.7 arrays/ms)

Parsing 2000 arrays took 432.4ms (4.6 arrays/ms)

Parsing 2000 arrays took 430.7ms (4.6 arrays/ms)

Parsing 2000 arrays took 429.2ms (4.7 arrays/ms)

real    0m4.568s
user    0m4.629s
sys     0m0.119s
```

Net: completes in less than a fifth of the time.